### PR TITLE
Remove TMPro dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
     "url": "https://github.com/realitycollective"
   },
   "dependencies": {
-    "com.realitytoolkit.core": "1.0.0-pre.18",
-    "com.realitytoolkit.camera": "1.0.1-pre.5",
-    "com.unity.textmeshpro": "3.0.6"
+    "com.realitytoolkit.core": "1.0.0-pre.29",
+    "com.realitytoolkit.camera": "1.0.1-pre.5"
   },
   "assets": [
     {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

This was an easy one, must have been copy-paste. For some reason this package had a dependency on TMPro when it really does not need one at all.
